### PR TITLE
sysinitでhttpdを起動

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,15 @@
 FROM centos:7
+ENV container docker
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
+systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*;\
+rm -f /etc/systemd/system/*.wants/*;\
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*;\
+rm -f /lib/systemd/system/anaconda.target.wants/*;
+VOLUME [ "/sys/fs/cgroup" ]
 
 RUN yum install -y wget
 RUN yum groupinstall -y "Development Tools"
@@ -6,8 +17,10 @@ RUN yum install -y nmap-ncat
 
 RUN yum install -y httpd
 RUN yum install -y httpd-devel
+RUN systemctl enable httpd.service
 COPY httpd/conf.d/01-cgi.conf /etc/httpd/conf.d
 COPY cgi-bin/index.cgi /var/www/cgi-bin/
+EXPOSE 80
 
 RUN yum install -y mariadb
 RUN yum install -y mariadb-libs
@@ -19,5 +32,4 @@ RUN yum install -y perl-devel
 RUN yum install -y perl-App-cpanminus
 RUN cpanm Carton
 
-EXPOSE 80
-CMD ["/usr/sbin/httpd", "-D", "FOREGROUND"]
+CMD ["/usr/sbin/init"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,5 +8,6 @@ services:
       - .:/code
     depends_on:
       - mariadb
+    privileged: true
   mariadb:
     image: circleci/mariadb:10.3


### PR DESCRIPTION
Dockerfileの最後でhttpdを直接実行していましたが、
通常のサーバの管理と同様に、sysinitで起動されるようにします。

## 参照

- https://www.opensourcetech.tokyo/entry/20190222/1550821994
- https://hub.docker.com/_/centos?tab=description
- http://docs.docker.jp/v1.12/engine/reference/run.html?highlight=run